### PR TITLE
Mirror of haskell vector#329

### DIFF
--- a/Data/Vector.hs
+++ b/Data/Vector.hs
@@ -115,7 +115,7 @@ module Data.Vector (
 
   -- ** Filtering
   filter, ifilter, uniq,
-  mapMaybe, imapMaybe,
+  mapMaybe, imapMaybe, catMaybes,
   filterM,
   takeWhile, dropWhile,
 
@@ -1287,6 +1287,11 @@ mapMaybe = G.mapMaybe
 imapMaybe :: (Int -> a -> Maybe b) -> Vector a -> Vector b
 {-# INLINE imapMaybe #-}
 imapMaybe = G.imapMaybe
+
+-- | /O(n)/ Return a Vector of all the Just values.
+catMaybes :: Vector (Maybe a) -> Vector a
+{-# INLINE catMaybes #-}
+catMaybes = mapMaybe id
 
 -- | /O(n)/ Drop elements that do not satisfy the monadic predicate
 filterM :: Monad m => (a -> m Bool) -> Vector a -> m (Vector a)

--- a/Data/Vector/Fusion/Stream/Monadic.hs
+++ b/Data/Vector/Fusion/Stream/Monadic.hs
@@ -40,7 +40,7 @@ module Data.Vector.Fusion.Stream.Monadic (
   eqBy, cmpBy,
 
   -- * Filtering
-  filter, filterM, uniq, mapMaybe, takeWhile, takeWhileM, dropWhile, dropWhileM,
+  filter, filterM, uniq, mapMaybe, catMaybes, takeWhile, takeWhileM, dropWhile, dropWhileM,
 
   -- * Searching
   elem, notElem, find, findM, findIndex, findIndexM,
@@ -683,6 +683,9 @@ mapMaybe f (Stream step t) = Stream step' t
                                     Just b' -> Yield b' s'
                   Skip    s' -> return $ Skip s'
                   Done       -> return $ Done
+
+catMaybes :: Monad m => Stream m (Maybe a) -> Stream m a
+catMaybes = mapMaybe id
 
 -- | Drop elements which do not satisfy the monadic predicate
 filterM :: Monad m => (a -> m Bool) -> Stream m a -> Stream m a

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changes in NEXT_VERSION
 
+ * Added `catMaybes`
  * Added `MonadFix` instance for boxed vectors
  * New functions: `unfoldrExactN` and `unfoldrExactNM`
  * `mkType` from `Data.Vector.Generic` is deprecated in favor of


### PR DESCRIPTION
Mirror of haskell vector#329
Add `catMaybes` which provides same function as the one found in `Data.Maybe`.

I thought this would be a useful function to have. Unfortunately the tests give me a type error when I added the property (in all honesty I don't understand the `VectorContext` constraint right now). But I thought that I'd hear thoughts about adding this before dedicating more time to it. 

Thanks!
